### PR TITLE
Load cover art when creating notification instead of when creating metadata objects

### DIFF
--- a/app/src/main/java/me/vanpetegem/accentor/media/NotificationBuilder.kt
+++ b/app/src/main/java/me/vanpetegem/accentor/media/NotificationBuilder.kt
@@ -10,10 +10,13 @@ import android.content.Intent
 import android.support.v4.media.session.PlaybackStateCompat
 import android.view.KeyEvent
 import androidx.core.app.NotificationCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.media.app.NotificationCompat.MediaStyle
 import androidx.media2.common.MediaMetadata
 import androidx.media2.common.SessionPlayer
 import androidx.media2.session.MediaSession
+import coil.imageLoader
+import coil.request.ImageRequest
 import me.vanpetegem.accentor.R
 import me.vanpetegem.accentor.ui.main.MainActivity
 
@@ -50,7 +53,7 @@ class NotificationBuilder(private val context: Context) {
     private val stopPendingIntent =
         createPendingIntent(PlaybackStateCompat.ACTION_STOP)
 
-    fun buildNotification(session: MediaSession): Notification {
+    suspend fun buildNotification(session: MediaSession): Notification {
         if (shouldCreateNowPlayingChannel()) {
             createNowPlayingChannel()
         }
@@ -77,11 +80,15 @@ class NotificationBuilder(private val context: Context) {
         val openIntent = Intent(context, MainActivity::class.java)
         val pendingIntent = PendingIntent.getActivity(context, 0, openIntent, 0)
 
+        val bitmap = metadata?.getString(MediaMetadata.METADATA_KEY_ALBUM_ART_URI)?.let {
+            context.imageLoader.execute(ImageRequest.Builder(context).data(it).build()).drawable?.toBitmap()
+        }
+
         return builder.setContentIntent(pendingIntent)
             .setContentTitle(metadata?.getString(MediaMetadata.METADATA_KEY_TITLE))
             .setContentText(metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST))
             .setDeleteIntent(stopPendingIntent)
-            .setLargeIcon(metadata?.getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART))
+            .setLargeIcon(bitmap)
             .setOnlyAlertOnce(true)
             .setSmallIcon(R.drawable.ic_notification)
             .setStyle(mediaStyle)


### PR DESCRIPTION
Also make sure to create the notification asynchronously.

<!---
  Thanks for contributing to Accentor!  Make sure all GitHub actions
  (test, lint & build) will pass and fill out the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->
 
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context. If your
  pull request includes visual changes (which will probably be the
  case for anything that isn't a pure logic fix), please include
  screenshots showing those changes. Note that the GitHub ToS requires
  you to have the intellectual property rights required to post
  copyrighted content, which you might not have for cover art included
  in your screenshot depending on your jurisdiction and the license
  of the cover art: https://docs.github.com/en/github/site-policy/github-terms-of-service#d-user-generated-content
  --->

Fixes #143.
Fixes #220.

<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
