### PR TITLE
Don't nest scope launches in MediaSessionConnection

### DIFF
--- a/app/src/main/java/me/vanpetegem/accentor/media/MediaSessionConnection.kt
+++ b/app/src/main/java/me/vanpetegem/accentor/media/MediaSessionConnection.kt
@@ -147,15 +147,17 @@ class MediaSessionConnection @Inject constructor(
     suspend fun stop() {
         mainScope.launch(Main) {
             mediaController.stop()
-            clearQueue()
+            mediaController.clearMediaItems()
         }
     }
 
     suspend fun play(tracks: List<Pair<Track, Album>>) {
         mainScope.launch(Main) {
-            stop()
+            mediaController.stop()
+            mediaController.clearMediaItems()
             mediaController.setMediaItems(tracks.map { convertTrack(it.first) })
-            play()
+            mediaController.prepare()
+            mediaController.play()
         }
     }
 


### PR DESCRIPTION
Nesting these launches resulted in bugs where items were cleared from the play queue after they were just added.
