### PR TITLE
Move cache to data storage

### DIFF
--- a/app/src/main/java/me/vanpetegem/accentor/Accentor.kt
+++ b/app/src/main/java/me/vanpetegem/accentor/Accentor.kt
@@ -37,7 +37,10 @@ class Accentor : Application(), ImageLoaderFactory {
     override fun newImageLoader(): ImageLoader =
         ImageLoader.Builder(applicationContext)
             .diskCache {
-                DiskCache.Builder().directory(File(cacheDir, "coil_image_cache")).build()
+                DiskCache.Builder()
+                    .directory(File(dataDir, "coil_image_cache"))
+                    .maxSizeBytes(preferences.imageCacheSize.value!!)
+                    .build()
             }
             .components {
                 if (Build.VERSION.SDK_INT >= 28) {

--- a/app/src/main/java/me/vanpetegem/accentor/media/MusicService.kt
+++ b/app/src/main/java/me/vanpetegem/accentor/media/MusicService.kt
@@ -71,7 +71,7 @@ class MusicService : MediaSessionService() {
     }
     private val cache: SimpleCache by lazy {
         SimpleCache(
-            File(this@MusicService.application.cacheDir, "audio"),
+            File(this@MusicService.application.dataDir, "audio"),
             LeastRecentlyUsedCacheEvictor(preferencesDataSource.musicCacheSize.value!!),
             StandaloneDatabaseProvider(this@MusicService.application)
         )


### PR DESCRIPTION
Some phones severely limit cache size, which makes the caching mechanism useless. Since we allow users to limit the size anyway, store the cached audio and image data in the data directory (Spotify and other similar apps do this also).
